### PR TITLE
Include tests in the pypi tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE_BSD PATENTS README.md LICENSE.txt
+recursive-include tests *.py


### PR DESCRIPTION
This allows Linux packagers to easily run the unit tests as part of the
build process.