### PR TITLE
compatibility with python35 and python34

### DIFF
--- a/pystemd/base.py
+++ b/pystemd/base.py
@@ -51,7 +51,7 @@ class SDObject(object):
         # https://github.com/systemd/systemd/blob/119f0f2876ea340cc41525e844487aa88551c219/src/core/dbus-unit.c#L1738-L1746
 
         for interface in self._interfaces.values():
-            if name in (*interface.properties, *interface.methods):
+            if name in (interface.properties + interface.methods):
                 return getattr(interface, name)
         raise AttributeError()
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -19,7 +19,9 @@ class TestContextManager(TestCase):
         with patch.object(SDObject, "load") as load:
             with self.assertRaises(ZeroDivisionError), SDObject(b"d", b"p"):
                 raise ZeroDivisionError("we shoudl raise this error")
-            load.assert_called_once()
+            # Do not use Mock.assert_called_once(), because its not
+            # present in python3.5
+            self.assertEqual(load.call_count, 1)
 
 
 class TestLoad(TestCase):
@@ -48,11 +50,15 @@ class TestLoad(TestCase):
 
         self.assertIn("prop1", obj.I1.properties)
         obj.I1.prop1  # getting a property
-        obj._bus.get_property.assert_called_once()
+        # Do not use Mock.assert_called_once(), because its not
+        # present in python3.5
+        self.assertEqual(obj._bus.get_property.call_count, 1)
 
         self.assertIn("meth1", obj.I1.methods)
         obj.I1.meth1(b"arg1")  # just calling a method
-        obj._bus.call_method.assert_called_once()
+        # Do not use Mock.assert_called_once(), because its not
+        # present in python3.5
+        self.assertEqual(obj._bus.call_method.call_count, 1)
 
         with self.assertRaises(TypeError):
             obj.I1.meth1()


### PR DESCRIPTION
Summary: travis was broken for python 3.4 and python 3.5 , this will fix it

Differential Revision: D14591778
