### PR TITLE
Fix minor spelling issues

### DIFF
--- a/pystemd/daemon.pyx
+++ b/pystemd/daemon.pyx
@@ -37,13 +37,13 @@ def notify(int unset_environment, *states, **kwstates):
 
   usage:
     * `pystemd.daemon.notify(1, ready=1)`: this will signal `READY=1` to systemd
-      notify and will remove all information from the enviroment. You should not
+      notify and will remove all information from the environment. You should not
       try to talk to systemd notify socket again.
     *  `pystemd.daemon.notify(True, "READY=1")`: same as above just passed as a
       string.
     *  `pystemd.daemon.notify(False, ready=1, status='gime gime gime')`: will
       signal systemd that the app is ready and also set the status to
-      'gime gime gime'. This command does not clean the notify enviroment.
+      'gime gime gime'. This command does not clean the notify environment.
 
     For info on sd_notify, check https://github.com/systemd/systemd/blob/\
 master/src/systemd/sd-daemon.h#L173-L232
@@ -69,7 +69,7 @@ def booted():
 
 def watchdog_enabled(int unset_environment=0):
   """
-  returns 0 if watchdog is not enable, and returns the number of usec between
+  returns 0 if watchdog is not enabled, and returns the number of usec between
   keep-alive notification messages that the service manager expects.
   """
 

--- a/pystemd/dbusexc.pyx
+++ b/pystemd/dbusexc.pyx
@@ -16,7 +16,7 @@ class DBusBaseError(Exception):
       is_base_error = self.__class__.__name__ == 'DBusBaseError'
       custom_msg = (
         "\nThis is DBusBaseError, a base error for DBus (i bet you did not "
-        "see that comming) if you need a special error, enhance "
+        "see that coming) if you need a special error, enhance "
         "pystemd.sysdexc module!."
       ) if is_base_error else ''
 

--- a/pystemd/dbuslib.pyx
+++ b/pystemd/dbuslib.pyx
@@ -90,8 +90,8 @@ cdef class DbusMessage:
 
     cpdef process_reply(self, bool with_headers):
         """
-          Read throught a sd_bus_message reply object and return the answer to that call
-          it loosly based on bus_message_dump in \
+          Read through a sd_bus_message reply object and return the answer to that call.
+          It's loosely based on bus_message_dump in \
           https://github.com/systemd/systemd/blob/master/src/libsystemd/sd-bus/bus-dump.c
           except that will dump to stdout, this will give you a nice python array (you
           are welcome!).
@@ -725,7 +725,7 @@ cpdef list apply_signature(char *signature, list values):
 
 
 cpdef bytes path_encode(char* prefix,  char* external_id):
-  """Python wraper for sd_bus_path_encode, it produce a encoded version of a
+  """Python wrapper for sd_bus_path_encode, it produce a encoded version of a
   systemd path:
 
   example:
@@ -752,7 +752,7 @@ cpdef bytes path_encode(char* prefix,  char* external_id):
 
 
 cpdef bytes path_decode(char* path,  char* prefix):
-  """Python wraper for sd_bus_path_decode, it produce a decoded version of a
+  """Python wrapper for sd_bus_path_decode, it produce a decoded version of a
   systemd path:
 
   example:


### PR DESCRIPTION
Hi!

We're working towards packaging pystemd in Debian: https://salsa.debian.org/python-team/modules/pystemd :)

Lintian, a tool that dissects debian packages for bugs and policy violations, reported a couple of spelling errors in pystemd's source.

This pull request fixes these errors. Please review and merge it.

Thanks for developing pystemd.