### PR TITLE
Include .pyx files in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md LICENSE
 recursive-include tests *.py
+recursive-include pystemd *.pyx

--- a/setup.py
+++ b/setup.py
@@ -55,21 +55,24 @@ else:
     __version__ += ".{}".format(release_tag)
 
 
-# If you are installing a clone of the repo, you should always compile the pyx
-# files into c code. since we never include the c files in the git repo.
-# But if you are installing this from a source distribution, then we dont pack
-# the pyx files, but we do pack the c extensions, so you need to use that.
-if glob.glob("pystemd/*.pyx"):
-    from Cython.Build import cythonize
-
-    external_modules = cythonize(
-        [Extension("*", ["pystemd/*.pyx"], libraries=["systemd"])]
-    )
-else:
+# Use C extensions if respective files are present. Else let Cython modules be
+# compiled to C code. The latter is the case when using a clone of the git
+# repository, unlike the source distribution which includes both .pyx and .c
+# files.
+if glob.glob("pystemd/*.c"):
     external_modules = [
         Extension(cext[:-2].replace("/", "."), [cext], libraries=["systemd"])
         for cext in glob.glob("pystemd/*.c")
     ]
+else:
+    try:
+        from Cython.Build import cythonize
+
+        external_modules = cythonize(
+            [Extension("*", ["pystemd/*.pyx"], libraries=["systemd"])]
+        )
+    except ImportError:
+        raise RuntimeError("Cython not installed.")
 
 
 setup(


### PR DESCRIPTION
This commit adds .pyx files in MANIFEST.in, thus includes Cython files
in pystemd source distribution (sdist).

The rationale behind this change is based on the following:

- Cython documentation [1] suggests distributing "the generated .c
  files as well as your Cython sources so that users can install your
  module without needing to have Cython available." Distributing .c
  files should be considered a helpful addition to the source
  distribution, they do not actually replace the .pyx files.
- Including .pyx files in source distribution is in accordance with
  LGPL 2.1 terms [2] reading: "Source code" for a work means the
  preferred form of the work for making modifications to it.
- Including .pyx files in sdist is especially important for Debian
  packaging where we need to be sure all binaries are able to be built
  reproducibly from their source.

Additionally, current commit restructures setup.py external_modules by
inversing their logic: if no pystemd/*.c files are found then cythonize
is called on .pyx files. Both file types which will be anyway included
in sdist.

[1]https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#distributing-cython-modules
[2]https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html