### PR TITLE
Run black on tests with the latest version

### DIFF
--- a/tests/test_dbuslib.py
+++ b/tests/test_dbuslib.py
@@ -37,7 +37,7 @@ class TestEncode(TestCase):
 
 class TestDBusError(TestCase):
     def test_connecting_to_serverless_socket_raises_connection_refused_error(
-        self
+        self,
     ) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             socket_path = pathlib.Path(temporary_directory) / "test_socket"


### PR DESCRIPTION
In Travis, we are using black 19.10b0, while the one I was running in my dev machine is 19.3b0. Let's blacken the file with the latest version of black, so our OS CI is green!

We might want to lock black to the same version we run internally