### PR TITLE
setup.py: remove * operator for unpacking lists

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,11 +74,9 @@ else:
     except ImportError:
         raise RuntimeError("Cython not installed.")
 
-package_data = [
-    "pystemd/RELEASE",
-    *glob.glob("pystemd/*.pyi"),
-    *glob.glob("pystemd/*/*.pyi"),
-]
+package_data = ["pystemd/RELEASE"]
+package_data.extend(glob.glob("pystemd/*.pyi"))
+package_data.extend(glob.glob("pystemd/*/*.pyi"))
 
 setup(
     name="pystemd",


### PR DESCRIPTION
The `*` operator is not supported in python 3.4. Replaced with `.extend()`.
Fixes `*glob.glob()` travis-ci error for python 3.4

Requires #45 