### PR TITLE
add a LIBSYSTEMD_VERSION macro for gating new functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Please note that CentOS 7 ships with version 219. To work around this, please re
 `libsystemd` depending on your distribution, version needs to be at least
 v237.
 * gcc: or any compiler that `setup.py` will accept.
+* [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/) command. Depending on your distro, the package is called "pkg-config", "pkgconfig" or a compatible substitute like "pkgconf"
 
 if you want to install from source then after you clone this repo you need to
 

--- a/pystemd/dbusc.pxd
+++ b/pystemd/dbusc.pxd
@@ -150,17 +150,6 @@ cdef extern from "systemd/sd-bus.h":
   const char *sd_bus_message_get_destination(sd_bus_message *m)
   const char *sd_bus_message_get_sender(sd_bus_message *m)
 
-  int sd_bus_match_signal(
-    sd_bus *bus,
-    sd_bus_slot **ret,
-    const char *sender,
-    const char *path,
-    const char *interface,
-    const char *member,
-    sd_bus_message_handler_t callback,
-    void *userdata
-  )
-
   sd_bus_message* sd_bus_message_ref(sd_bus_message *m)
   sd_bus_message* sd_bus_message_unref(sd_bus_message *m)
 
@@ -217,3 +206,6 @@ cdef union basic_data:
 
 cdef extern from 'stdbool.h':
   pass
+
+IF LIBSYSTEMD_VERSION >= 237:
+  include "dbusc_v237.pxi"

--- a/pystemd/dbusc_v237.pxi
+++ b/pystemd/dbusc_v237.pxi
@@ -1,0 +1,23 @@
+# cython: language_level=3
+#
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in
+# the root directory of this source tree.
+#
+
+# This header includes only the symbols from the v237+ releases of systemd:
+# https://raw.githubusercontent.com/systemd/systemd/v237/NEWS
+
+cdef extern from "systemd/sd-bus.h":
+  int sd_bus_match_signal(
+    sd_bus *bus,
+    sd_bus_slot **ret,
+    const char *sender,
+    const char *path,
+    const char *interface,
+    const char *member,
+    sd_bus_message_handler_t callback,
+    void *userdata
+  )

--- a/pystemd/dbuslib.pyx
+++ b/pystemd/dbuslib.pyx
@@ -496,25 +496,28 @@ cdef class DBus:
       https://github.com/facebookincubator/pystemd/blob/master/examples/monitor.py
       """
 
-      cdef int r
+      IF LIBSYSTEMD_VERSION < 237:
+          raise DBusError(-1, "sd_bus_match_signal not available in libsystemd v%d" % LIBSYSTEMD_VERSION)
+      ELSE:
+          cdef int r
 
-      callback.metadata = {
-        'userdata': userdata,
-      }
+          callback.metadata = {
+            'userdata': userdata,
+          }
 
-      r = dbusc.sd_bus_match_signal(
-        self.bus,
-        NULL,
-        _b2c(x2char_star(sender)),
-        _b2c(x2char_star(path)),
-        _b2c(x2char_star(interface)),
-        _b2c(x2char_star(member)),
-        match_signal_callback_handler,
-        <void*> callback
-      )
+          r = dbusc.sd_bus_match_signal(
+            self.bus,
+            NULL,
+            _b2c(x2char_star(sender)),
+            _b2c(x2char_star(path)),
+            _b2c(x2char_star(interface)),
+            _b2c(x2char_star(member)),
+            match_signal_callback_handler,
+            <void*> callback
+          )
 
-      if r < 0:
-        raise DBusError(r, "Failed to add signal match")
+          if r < 0:
+              raise DBusError(r, "Failed to add signal match")
 
     # Direct interface to sd_bus_<methods>
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,19 @@ from pathlib import Path
 from setuptools import setup
 from setuptools.extension import Extension
 
+import subprocess
+
+compile_time_env = {
+    'LIBSYSTEMD_VERSION': -1
+}
+
+try:
+    compile_time_env['LIBSYSTEMD_VERSION'] = int(subprocess.check_output(["pkg-config", "--modversion", "libsystemd"]))
+    # Extension has no means to interrogate pkg-config: https://bugs.python.org/issue28207#msg277413
+except FileNotFoundError as e:
+    sys.exit('"pkg-config" command could not be found. Please ensure "pkg-config" is installed into your PATH.')
+except subprocess.CalledProcessError as e:
+    sys.exit("`%s` failed. Please ensure all prerequisite packages from README.md are installed." % ' '.join(e.cmd))
 
 THIS_DIR = Path(__file__).parent
 
@@ -69,7 +82,12 @@ else:
         from Cython.Build import cythonize
 
         external_modules = cythonize(
-            [Extension("*", ["pystemd/*.pyx"], libraries=["systemd"])]
+            [Extension(
+                "*",
+                ["pystemd/*.pyx"],
+                libraries=["systemd"]
+            )],
+            compile_time_env=compile_time_env
         )
     except ImportError:
         raise RuntimeError("Cython not installed.")

--- a/setup.py
+++ b/setup.py
@@ -21,17 +21,22 @@ from setuptools.extension import Extension
 
 import subprocess
 
-compile_time_env = {
-    'LIBSYSTEMD_VERSION': -1
-}
+compile_time_env = {"LIBSYSTEMD_VERSION": -1}
 
 try:
-    compile_time_env['LIBSYSTEMD_VERSION'] = int(subprocess.check_output(["pkg-config", "--modversion", "libsystemd"]))
+    compile_time_env["LIBSYSTEMD_VERSION"] = int(
+        subprocess.check_output(["pkg-config", "--modversion", "libsystemd"])
+    )
     # Extension has no means to interrogate pkg-config: https://bugs.python.org/issue28207#msg277413
 except FileNotFoundError as e:
-    sys.exit('"pkg-config" command could not be found. Please ensure "pkg-config" is installed into your PATH.')
+    sys.exit(
+        '"pkg-config" command could not be found. Please ensure "pkg-config" is installed into your PATH.'
+    )
 except subprocess.CalledProcessError as e:
-    sys.exit("`%s` failed. Please ensure all prerequisite packages from README.md are installed." % ' '.join(e.cmd))
+    sys.exit(
+        "`%s` failed. Please ensure all prerequisite packages from README.md are installed."
+        % " ".join(e.cmd)
+    )
 except ValueError as e:
     sys.exit("libsystemd version returned by pkg-config is not a plain integer!")
 
@@ -84,12 +89,8 @@ else:
         from Cython.Build import cythonize
 
         external_modules = cythonize(
-            [Extension(
-                "*",
-                ["pystemd/*.pyx"],
-                libraries=["systemd"]
-            )],
-            compile_time_env=compile_time_env
+            [Extension("*", ["pystemd/*.pyx"], libraries=["systemd"])],
+            compile_time_env=compile_time_env,
         )
     except ImportError:
         raise RuntimeError("Cython not installed.")

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ except FileNotFoundError as e:
     sys.exit('"pkg-config" command could not be found. Please ensure "pkg-config" is installed into your PATH.')
 except subprocess.CalledProcessError as e:
     sys.exit("`%s` failed. Please ensure all prerequisite packages from README.md are installed." % ' '.join(e.cmd))
+except ValueError as e:
+    sys.exit("libsystemd version returned by pkg-config is not a plain integer!")
 
 THIS_DIR = Path(__file__).parent
 


### PR DESCRIPTION
This allows gating of function-symbols based on the builder's own libsystemd version.

Unfortunately cython doesn't translate both branches of the IF-ELSE from *.pyx into the intermediate *.c files, so if you build source zips on a host with a newer libsystemd, that version's symbols will be expected to be available for the final compile.

I guess that users needing to support older systemd installations are most likely going to be starting from a clean .git checkout and using cython, not a dist .zip, so perhaps that's not a big deal?

I didn't make a note of it in the README since we only seem to have one sd_ function that's not totally in the field yet and eventually these older versions should die off...

Fixes #26